### PR TITLE
Use target_compile_defs with exported defs from industrial_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ catkin_package(
   CATKIN_DEPENDS industrial_robot_client
 )
 
-add_definitions(-DLINUXSOCKETS=1)
-
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
@@ -25,6 +23,10 @@ target_link_libraries(${PROJECT_NAME}_robot_state
 set_target_properties(
   ${PROJECT_NAME}_robot_state
   PROPERTIES OUTPUT_NAME robot_state PREFIX "")
+target_compile_definitions(
+  ${PROJECT_NAME}_robot_state
+  PRIVATE
+  ${industrial_robot_client_DEFINITIONS})
 
 add_executable(${PROJECT_NAME}_motion_download_interface
   src/abb_joint_downloader_node.cpp
@@ -35,7 +37,10 @@ target_link_libraries(${PROJECT_NAME}_motion_download_interface
   ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_motion_download_interface
   PROPERTIES OUTPUT_NAME motion_download_interface PREFIX "")
-
+target_compile_definitions(
+  ${PROJECT_NAME}_motion_download_interface
+  PRIVATE
+  ${industrial_robot_client_DEFINITIONS})
 
 install(
   TARGETS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(abb_driver)
-add_definitions(-std=c++11)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(catkin REQUIRED COMPONENTS industrial_robot_client simple_message)
 
 catkin_package(


### PR DESCRIPTION
Since https://github.com/ros-industrial/industrial_core/pull/262, `industrial_core` exports its compiler definitions.

`abb_driver` depends on `industrial_robot_client` and `simple_message`, and should use those exported definitions, instead of hard-coding them in its own `CMakeLists.txt`.

The changes in this PR do that.

Note: this PR will fail CI until `industrial_core` sees a new release, as the CI configuration installs `industrial_core` using the released packages. As the most recent release of `industrial_core` does not include https://github.com/ros-industrial/industrial_core/pull/262, the variable referenced in this PR does not exist and the build will fail.
