### PR TITLE
Increase minimum CMake version to allow builds on Focal Fossa (Noetic)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(abb_driver)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Related to https://github.com/ros-industrial/ros_industrial_issues/issues/67