### PR TITLE
stop enforcing c++ 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(abb_driver)
 
-set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(catkin REQUIRED COMPONENTS industrial_robot_client simple_message)


### PR DESCRIPTION
Melodic defaults to C++14 already, ROS one requires C++ 17 due to log4cxx so C++ 11 should not be enforced